### PR TITLE
Set the force flag in the prepare command

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -76,7 +76,7 @@ jobs:
         run: brew install superfaceai/cli/superface
       - run: superface --version
       - run: superface whoami
-      - run: superface prepare ./openapi.yaml superface-daily
+      - run: superface prepare --force ./openapi.yaml superface-daily
       - run: superface new superface-daily "get a greeting" superface-daily/get-greeting
       - run: superface map superface-daily superface-daily/get-greeting
       - run: superface map superface-daily superface-daily/get-greeting python


### PR DESCRIPTION
This PR adds new --force flag to the prepare command. Force flag is required to reindex provider since Superface CLI version @superfaceai/cli/4.1.3
